### PR TITLE
For extlinux, add "linux" as a synonym for "kernel".

### DIFF
--- a/grubby.c
+++ b/grubby.c
@@ -595,6 +595,7 @@ struct keywordTypes extlinuxKeywords[] = {
 	{"root", LT_ROOT, ' '},
 	{"default", LT_DEFAULT, ' '},
 	{"kernel", LT_KERNEL, ' '},
+	{"linux", LT_KERNEL, ' '},
 	{"initrd", LT_INITRD, ' ', ','},
 	{"append", LT_KERNELARGS, ' '},
 	{"prompt", LT_UNKNOWN, ' '},


### PR DESCRIPTION
For my kernels, extlinux fails to boot with the "kernel" keyword, and needs to use "linux" instead; it is something to do with the kernel size.
