### PR TITLE
Use FIFREEZE after fsync()

### DIFF
--- a/new-kernel-pkg
+++ b/new-kernel-pkg
@@ -926,6 +926,9 @@ fi
 # PPC64LE-only to deal with Petitboot issues
 if [ "$ARCH" = "ppc64le" ]; then
     sync && mountpoint -q /boot && fsfreeze -f /boot && fsfreeze -u /boot
+# x86_64 + aarch64: no need to sync before fsfreeze
+elif [ "$ARCH" = "x86_64" ] || [ "$ARCH" = "aarch64" ]; then
+    mountpoint -q /boot && fsfreeze -f /boot && fsfreeze -u /boot
 fi
 
 exit 0


### PR DESCRIPTION
If /boot is a journaling file system, the only guarantee grubby has after d9406b0 is that the journal and data of that file system are committed to stable media, but not metadata.
So, provided umount succeeds or a proper journal recovery is done if needed, grub.cfg's content should be consistent with the latest update done by grubby.
However, as grub2 does not read journals, if the journal was not replayed (e.g. dirty), more or less undefined behavior will occur.

Using FIFREEZE after fflush/fsync will sync() + write all log contents to the file system, leaving it in a state where grub2 can reliably find and read grub.conf as last written to.

Note that I explicitly avoided using FIFREEZE if /boot and / belong to the same file system - I think this would be wrong for many reasons.