### PR TITLE
new-kernel-pkg: Add --dracutoptions

### DIFF
--- a/new-kernel-pkg
+++ b/new-kernel-pkg
@@ -110,7 +110,7 @@ mode=""
 version=""
 initrd=""
 dracut=""
-dracuthostonly=""
+dracutoptions=""
 initrdfile=""
 devtreefile=""
 moddep=""
@@ -129,8 +129,8 @@ usage() {
     echo "       [--kernel-args=<args>] [--remove-args=<args>]" >&2
     echo "       [--banner=<banner>] [--multiboot=multiboot]" >&2
     echo "       [--mbargs=mbargs] [--make-default] [--add-dracut-args]" >&2
-    echo "       [--add-plymouth-initrd]" >&2
-    echo "       [--host-only] [--devtree=<devicetree.dtb>] [--devtreedir=</devicetree/path/>]" >&2
+    echo "       [--add-plymouth-initrd] [--host-only] [--dracutoptions]" >&2
+    echo "       [--devtree=<devicetree.dtb>] [--devtreedir=</devicetree/path/>]" >&2
     echo "       <--install | --remove | --update | --rpmposttrans> <kernel-version>" >&2
     echo "       (ex: `basename $0` --mkinitrd --depmod --install 2.4.7-2)" >&2
     exit 1
@@ -580,7 +580,7 @@ update() {
 
 doMkinitrd() {
     if [ -n "$dracut" ]; then
-        tool="dracut $dracuthostonly -f $initrdfile $version"
+	tool="dracut $dracutoptions -f $initrdfile $version"
     else
 	tool="mkinitrd --allow-missing -f $initrdfile $version"
     fi
@@ -650,8 +650,13 @@ while [ $# -gt 0 ]; do
 	    dracut=--dracut
 	    ;;
 
+	--dracutoptions*)
+	    dracutoptions="$1 $dracutoptions"
+	    dracutoptions=${dracutoptions#*=}
+	    ;;
+
 	--host-only)
-	    dracuthostonly=-H
+	    dracutoptions="$dracutoptions -H"
 	    ;;
 
 	--initrdfile*)

--- a/new-kernel-pkg.8
+++ b/new-kernel-pkg.8
@@ -8,7 +8,8 @@ new-kernel-pkg \- tool to script kernel installation
        [--kernel-args=\fIargs\fR] [--remove-args=\fIargs\fR]
        [--banner=\fIbanner\fR] [--multiboot=\fImultiboot\fR]
        [--mbargs=\fImbargs\fR] [--make-default] [--add-dracut-args]
-       [--add-plymouth-initrd] [--host-only] [--devtree=\fIdevicetree.dtb\fR]
+       [--add-plymouth-initrd] [--host-only] [--dracutoptions]
+       [--devtree=\fIdevicetree.dtb\fR]
        <--install | --remove | --update | --rpmposttrans> <kernel-version>
 
 .SH DESCRIPTION
@@ -102,6 +103,10 @@ Update the specified kernel.
 .TP
 \fB-\-rpmposttrans\fR \fIkernel-version\fR
 Run the rpmposttrans for the specified kernel.
+
+.TP
+\fB-\-dracutoptions\fR=\fIoptions\fR
+Pass options to dracut.
 
 .SH "SEE ALSO"
 .BR grubby(8)


### PR DESCRIPTION
I want to create an initramfs using xz compression but there is no way to
do that from new-kernel-pkg.  Add --dracutoptions which is a list of
options that will be added to the dracut command line.

I have tested this with "make test": 269 (100%) tests passed, 0 (0%) tests failed

Signed-off-by: Prarit Bhargava <prarit@redhat.com>