### PR TITLE
Use /boot/loader/entries as BLS directory path also on EFI systems

### DIFF
--- a/grubby-bls
+++ b/grubby-bls
@@ -561,10 +561,6 @@ done
 
 if [[ -z $blsdir ]]; then
     blsdir="/boot/loader/entries"
-    if [[ -d /sys/firmware/efi ]]; then
-	efidir="$(grep ^ID= /etc/os-release | sed -e 's/^ID=//' -e 's/rhel/redhat/')"
-	blsdir="/boot/efi/EFI/${efidir}/loader/entries"
-    fi
 fi
 
 if [[ -z $env ]]; then


### PR DESCRIPTION
For EFI systems, the BLS fragments were stored in the EFI System Partition
(ESP) in /EFI/fedora/loader/entries while in non-EFI systems it was stored
in /loader/entries in the boot partition mounted on /boot.

For consistency, it's better to always store the BLS fragments in the same
path regardless of the firmware interface used.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>