### PR TITLE
Recognize extlinux "linux" keyword

### DIFF
--- a/grubby.c
+++ b/grubby.c
@@ -601,6 +601,7 @@ struct keywordTypes extlinuxKeywords[] = {
 	{"root", LT_ROOT, ' '},
 	{"default", LT_DEFAULT, ' '},
 	{"kernel", LT_KERNEL, ' '},
+	{"linux", LT_KERNEL, ' '},
 	{"initrd", LT_INITRD, ' ', ','},
 	{"append", LT_KERNELARGS, ' '},
 	{"prompt", LT_UNKNOWN, ' '},

--- a/test/extlinux.4
+++ b/test/extlinux.4
@@ -8,22 +8,22 @@ prompt 10
 default Fedora (3.13.0-0.rc0.git5.1.fc21.i686) 20 (Heisenbug)
 
 label Fedora (3.11.7-300.fc20.i686) 20 (Heisenbug)
-kernel /boot/vmlinuz-3.11.7-300.fc20.i686
+linux /boot/vmlinuz-3.11.7-300.fc20.i686
 append ro root=/dev/hda6
 initrd /boot/initrd-3.11.7-300.fc20.i686.img
 
 label Fedora (3.11.7-301.fc20.i686) 20 (Heisenbug)
-kernel /boot/vmlinuz-3.11.7-301.fc20.i686
+linux /boot/vmlinuz-3.11.7-301.fc20.i686
 append ro root=/dev/hda6
 initrd /boot/initrd-3.11.7-301.fc20.i686.img
 
 label Fedora (3.13.0-0.rc0.git5.1.fc21.i686) 20 (Heisenbug)
-kernel /boot/vmlinuz-3.13.0-0.rc0.git5.1.fc21.i686
+linux /boot/vmlinuz-3.13.0-0.rc0.git5.1.fc21.i686
 append ro root=/dev/hda6
 initrd /boot/initrd-3.13.0-0.rc0.git5.1.fc21.i686.img
 
 label Fedora (3.12.0-2.fc21.i686) 20 (Heisenbug)
-kernel /vmlinuz-3.12.0-2.fc21.i686
+linux /vmlinuz-3.12.0-2.fc21.i686
 append ro root=/dev/sda1 console=tty0 console=ttyS1,9600n81
 initrd /initrd-3.12.0-2.fc21.i686.img
 

--- a/test/results/remove/extlinux4.1
+++ b/test/results/remove/extlinux4.1
@@ -8,17 +8,17 @@ prompt 10
 default Fedora (3.13.0-0.rc0.git5.1.fc21.i686) 20 (Heisenbug)
 
 label Fedora (3.11.7-300.fc20.i686) 20 (Heisenbug)
-kernel /boot/vmlinuz-3.11.7-300.fc20.i686
+linux /boot/vmlinuz-3.11.7-300.fc20.i686
 append ro root=/dev/hda6
 initrd /boot/initrd-3.11.7-300.fc20.i686.img
 
 label Fedora (3.13.0-0.rc0.git5.1.fc21.i686) 20 (Heisenbug)
-kernel /boot/vmlinuz-3.13.0-0.rc0.git5.1.fc21.i686
+linux /boot/vmlinuz-3.13.0-0.rc0.git5.1.fc21.i686
 append ro root=/dev/hda6
 initrd /boot/initrd-3.13.0-0.rc0.git5.1.fc21.i686.img
 
 label Fedora (3.12.0-2.fc21.i686) 20 (Heisenbug)
-kernel /vmlinuz-3.12.0-2.fc21.i686
+linux /vmlinuz-3.12.0-2.fc21.i686
 append ro root=/dev/sda1 console=tty0 console=ttyS1,9600n81
 initrd /initrd-3.12.0-2.fc21.i686.img
 

--- a/test/results/updargs/extlinux4.2
+++ b/test/results/updargs/extlinux4.2
@@ -8,22 +8,22 @@ prompt 10
 default Fedora (3.13.0-0.rc0.git5.1.fc21.i686) 20 (Heisenbug)
 
 label Fedora (3.11.7-300.fc20.i686) 20 (Heisenbug)
-kernel /boot/vmlinuz-3.11.7-300.fc20.i686
+linux /boot/vmlinuz-3.11.7-300.fc20.i686
 append ro root=/dev/hda6 hde=ide-scsi
 initrd /boot/initrd-3.11.7-300.fc20.i686.img
 
 label Fedora (3.11.7-301.fc20.i686) 20 (Heisenbug)
-kernel /boot/vmlinuz-3.11.7-301.fc20.i686
+linux /boot/vmlinuz-3.11.7-301.fc20.i686
 append ro root=/dev/hda6 hde=ide-scsi
 initrd /boot/initrd-3.11.7-301.fc20.i686.img
 
 label Fedora (3.13.0-0.rc0.git5.1.fc21.i686) 20 (Heisenbug)
-kernel /boot/vmlinuz-3.13.0-0.rc0.git5.1.fc21.i686
+linux /boot/vmlinuz-3.13.0-0.rc0.git5.1.fc21.i686
 append ro root=/dev/hda6 hde=ide-scsi
 initrd /boot/initrd-3.13.0-0.rc0.git5.1.fc21.i686.img
 
 label Fedora (3.12.0-2.fc21.i686) 20 (Heisenbug)
-kernel /vmlinuz-3.12.0-2.fc21.i686
+linux /vmlinuz-3.12.0-2.fc21.i686
 append ro root=/dev/sda1 console=tty0 console=ttyS1,9600n81 hde=ide-scsi
 initrd /initrd-3.12.0-2.fc21.i686.img
 

--- a/test/results/updargs/extlinux4.3
+++ b/test/results/updargs/extlinux4.3
@@ -8,22 +8,22 @@ prompt 10
 default Fedora (3.13.0-0.rc0.git5.1.fc21.i686) 20 (Heisenbug)
 
 label Fedora (3.11.7-300.fc20.i686) 20 (Heisenbug)
-kernel /boot/vmlinuz-3.11.7-300.fc20.i686
+linux /boot/vmlinuz-3.11.7-300.fc20.i686
 append ro root=/dev/hda6
 initrd /boot/initrd-3.11.7-300.fc20.i686.img
 
 label Fedora (3.11.7-301.fc20.i686) 20 (Heisenbug)
-kernel /boot/vmlinuz-3.11.7-301.fc20.i686
+linux /boot/vmlinuz-3.11.7-301.fc20.i686
 append ro root=/dev/hda6
 initrd /boot/initrd-3.11.7-301.fc20.i686.img
 
 label Fedora (3.13.0-0.rc0.git5.1.fc21.i686) 20 (Heisenbug)
-kernel /boot/vmlinuz-3.13.0-0.rc0.git5.1.fc21.i686
+linux /boot/vmlinuz-3.13.0-0.rc0.git5.1.fc21.i686
 append ro root=/dev/hda6 hde=ide-scsi
 initrd /boot/initrd-3.13.0-0.rc0.git5.1.fc21.i686.img
 
 label Fedora (3.12.0-2.fc21.i686) 20 (Heisenbug)
-kernel /vmlinuz-3.12.0-2.fc21.i686
+linux /vmlinuz-3.12.0-2.fc21.i686
 append ro root=/dev/sda1 console=tty0 console=ttyS1,9600n81
 initrd /initrd-3.12.0-2.fc21.i686.img
 

--- a/test/results/updargs/extlinux4.4
+++ b/test/results/updargs/extlinux4.4
@@ -8,22 +8,22 @@ prompt 10
 default Fedora (3.13.0-0.rc0.git5.1.fc21.i686) 20 (Heisenbug)
 
 label Fedora (3.11.7-300.fc20.i686) 20 (Heisenbug)
-kernel /boot/vmlinuz-3.11.7-300.fc20.i686
+linux /boot/vmlinuz-3.11.7-300.fc20.i686
 append ro root=/dev/hda6
 initrd /boot/initrd-3.11.7-300.fc20.i686.img
 
 label Fedora (3.11.7-301.fc20.i686) 20 (Heisenbug)
-kernel /boot/vmlinuz-3.11.7-301.fc20.i686
+linux /boot/vmlinuz-3.11.7-301.fc20.i686
 append ro root=/dev/hda6
 initrd /boot/initrd-3.11.7-301.fc20.i686.img
 
 label Fedora (3.13.0-0.rc0.git5.1.fc21.i686) 20 (Heisenbug)
-kernel /boot/vmlinuz-3.13.0-0.rc0.git5.1.fc21.i686
+linux /boot/vmlinuz-3.13.0-0.rc0.git5.1.fc21.i686
 append ro root=/dev/hda6
 initrd /boot/initrd-3.13.0-0.rc0.git5.1.fc21.i686.img
 
 label Fedora (3.12.0-2.fc21.i686) 20 (Heisenbug)
-kernel /vmlinuz-3.12.0-2.fc21.i686
+linux /vmlinuz-3.12.0-2.fc21.i686
 append ro root=LABEL=/ console=tty0 console=ttyS1,9600n81 single
 initrd /initrd-3.12.0-2.fc21.i686.img
 

--- a/test/results/updargs/extlinux4.5
+++ b/test/results/updargs/extlinux4.5
@@ -8,22 +8,22 @@ prompt 10
 default Fedora (3.13.0-0.rc0.git5.1.fc21.i686) 20 (Heisenbug)
 
 label Fedora (3.11.7-300.fc20.i686) 20 (Heisenbug)
-kernel /boot/vmlinuz-3.11.7-300.fc20.i686
+linux /boot/vmlinuz-3.11.7-300.fc20.i686
 append ro root=/dev/hda2
 initrd /boot/initrd-3.11.7-300.fc20.i686.img
 
 label Fedora (3.11.7-301.fc20.i686) 20 (Heisenbug)
-kernel /boot/vmlinuz-3.11.7-301.fc20.i686
+linux /boot/vmlinuz-3.11.7-301.fc20.i686
 append ro root=/dev/hda2
 initrd /boot/initrd-3.11.7-301.fc20.i686.img
 
 label Fedora (3.13.0-0.rc0.git5.1.fc21.i686) 20 (Heisenbug)
-kernel /boot/vmlinuz-3.13.0-0.rc0.git5.1.fc21.i686
+linux /boot/vmlinuz-3.13.0-0.rc0.git5.1.fc21.i686
 append ro root=/dev/hda2
 initrd /boot/initrd-3.13.0-0.rc0.git5.1.fc21.i686.img
 
 label Fedora (3.12.0-2.fc21.i686) 20 (Heisenbug)
-kernel /vmlinuz-3.12.0-2.fc21.i686
+linux /vmlinuz-3.12.0-2.fc21.i686
 append ro root=/dev/hda2 console=tty0 console=ttyS1,9600n81
 initrd /initrd-3.12.0-2.fc21.i686.img
 


### PR DESCRIPTION
Since some time ago, new kernels stopped getting installed on my Fedora
machine. Turns out, that it was because it didn't understand the "linux"
keyword. It can alternatively (preferrably?) be used to boot Linux images.