### PR TITLE
Adding documentation regarding return values and exit status sections to the man pages

### DIFF
--- a/grubby.8
+++ b/grubby.8
@@ -1,4 +1,4 @@
-.TH GRUBBY 8 "Tue Jan 18 2005"
+.TH GRUBBY 8 "Sun Oct 14 2018"
 
 .SH NAME
 
@@ -323,6 +323,15 @@ an argument already exists the new value replaces the old values.
 \fB-\-remove-mbargs\fR=\fImultiboot-args\fR
 The arguments specified by \fImultiboot-args\fR are removed from the
 kernels specified by \fB-\-update-kernel\fR.
+
+.SH "EXIT STATUS"
+
+If valid information about the current setup was correctly retrieved or if
+the grub configuration adjustment completed successfully, a value of 0 is
+returned.
+
+If an error is encountered or if grubby was unable to find the requested
+config information, a value of 1 is returned.
 
 .SH "BUGS"
 

--- a/installkernel.8
+++ b/installkernel.8
@@ -1,4 +1,4 @@
-.TH INSTALLKERNEL 8 "Wed Apr 14 2010"
+.TH INSTALLKERNEL 8 "Sun Oct 14 2018"
 .SH NAME
 installkernel \- tool to script kernel installation
 
@@ -14,6 +14,13 @@ The new kernel is installed into {directory}/vmlinuz-{version}. If a
 symbolic link {directory}/vmlinuz already exists, it is refreshed by
 making a link from {directory}/vmlinuz to the new kernel, and the
 previously installed kernel is available as {directory}/vmlinuz.old.
+
+.SH "EXIT STATUS"
+
+This script makes use of the kernel-install program. Specifically, if
+every executable returns 0 or 77, then 0 is returned.
+
+In the event of an error or failure, then a non-zero code is returned.
 
 .SH "SEE ALSO"
 .BR grubby(8)

--- a/new-kernel-pkg.8
+++ b/new-kernel-pkg.8
@@ -1,4 +1,4 @@
-.TH NEW-KERNEL-PKG 8 "Wed Apr 14 2010"
+.TH NEW-KERNEL-PKG 8 "Sun Oct 14 2018"
 .SH NAME
 new-kernel-pkg \- tool to script kernel installation
 
@@ -102,6 +102,14 @@ Update the specified kernel.
 .TP
 \fB-\-rpmposttrans\fR \fIkernel-version\fR
 Run the rpmposttrans for the specified kernel.
+
+.SH "EXIT STATUS"
+
+If the new kernel was successfully installed or updated, a value of 0 is
+returned.
+
+If the program is improperly called or an error is encountered, a value
+of 1 is returned.
 
 .SH "SEE ALSO"
 .BR grubby(8)


### PR DESCRIPTION
Related to issue #33, I have since added text to the man pages of each of the tools in this repo. This is done for the purpose of documenting the exit status and return values.