### PR TITLE
Fix debug build failure in subvolPrefix()

### DIFF
--- a/grubby.c
+++ b/grubby.c
@@ -2233,7 +2233,7 @@ static size_t subvolPrefix(const char *str)
 		}
 	}
 
-	dbgPrintf("%s(): str: '%s', prfx: '%s'\n", __FUNCTION__, str, prfx);
+	dbgPrintf("%s(): str: '%s', prfx: '%Zu'\n", __FUNCTION__, str, prfx);
 
 	fclose(file);
 	free(line);


### PR DESCRIPTION
This commit resolves the following debug build failure:

grubby.c: In function ‘subvolPrefix’:
grubby.c:2236:2: error: format ‘%s’ expects argument of type ‘char *’, but argument 5 has type ‘size_t’ [-Werror=format=]
  dbgPrintf("%s(): str: '%s', prfx: '%s'\n", __FUNCTION__, str, prfx);
  ^
cc1: all warnings being treated as errors

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>