### PR TITLE
grubby-bls: strip only /boot from paths

### DIFF
--- a/grubby-bls
+++ b/grubby-bls
@@ -389,24 +389,29 @@ set_default_bls() {
 }
 
 remove_var_prefix() {
+    local prefix="*"
+    if [[ -n ${GRUBBY_STRIP_BOOT_PREFIX} ]]; then
+        prefix="/boot"
+    fi
+
     if [[ -n $remove_kernel && $remove_kernel =~ ^/ ]]; then
-       remove_kernel="/${remove_kernel##*/}"
+       remove_kernel="/${remove_kernel##${prefix}/}"
     fi
 
     if [[ -n $initrd ]]; then
-	initrd="/${initrd##*/}"
+	initrd="/${initrd##${prefix}/}"
     fi
 
     if [[ -n $extra_initrd ]]; then
-	extra_initrd=" /${extra_initrd##*/}"
+	extra_initrd=" /${extra_initrd##${prefix}/}"
     fi
 
     if [[ -n $kernel ]]; then
-	kernel="/${kernel##*/}"
+	kernel="/${kernel##${prefix}/}"
     fi
 
     if [[ -n $update_kernel && $update_kernel =~ ^/ ]]; then
-	update_kernel="/${update_kernel##*/}"
+	update_kernel="/${update_kernel##${prefix}/}"
     fi
 }
 


### PR DESCRIPTION
When setting GRUBBY_STRIP_BOOT_PREFIX environment variable, grubby-bls
will strip only /boot instead of the entire path, this will allow to
place the kernel and initrd in subdirectories under /boot

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>